### PR TITLE
Fix React Flow dependency version

### DIFF
--- a/my-ux-sandbox/package.json
+++ b/my-ux-sandbox/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@xyflow/react": "^11.7.6"
+    "@xyflow/react": "^11.7.5"
   },
   "devDependencies": {
     "vite": "^4.4.9",


### PR DESCRIPTION
## Summary
- adjust the `@xyflow/react` dependency to a published release so installs succeed

## Testing
- npm install *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_686b8448fd58832aba3e1b5eb06dd8c5